### PR TITLE
Any namespace CSS selector

### DIFF
--- a/source/FluidXml/CssTranslator.php
+++ b/source/FluidXml/CssTranslator.php
@@ -48,6 +48,13 @@ class CssTranslator
                   '\1:',
                   'NS',
                   false ],
+                // *|A
+                [ '\*           # Namespace wildcard
+                   \|
+                   (\w+)',
+                  '*[local-name() = \'\1\']',
+                  'NS',
+                  false ],
                 // :root
                 [ ':root\b',
                   '/*',

--- a/specs/FluidXml.php
+++ b/specs/FluidXml.php
@@ -2778,23 +2778,30 @@ describe('FluidHelper', function () {
 
 describe('CssTranslator', function () {
         describe('.xpath()', function () {
-                $hml = new FluidXml([ 'html' => [ 'body' => [ 'div' =>
-                        [ 'p'  => [ '@class' => 'a', '@id' => '123', [ 'span' ] ],
-                          'h1' => [ '@class' => 'b' ],
-                          'p'  => [ '@class' => 'a b' ],
-                          'p'  => [ '@class' => 'a' ]    ]
-                ]]]);
+                $hml = new FluidXml([ 'html' => [
+                        'body' => [
+                                'div' => [
+                                        [ 'p'  => [ '@class' => 'a', '@id' => '123', [ 'span' ] ] ],
+                                        [ 'h1' => [ '@class' => 'b' ] ],
+                                        [ 'shape' => [ '@class' => 'c' ] ],
+                                        [ 'p'  => [ '@class' => 'a b' ] ],
+                                        [ 'p'  => [ '@class' => 'a' ] ],
+                                        [ 'span'  => [ '@class' => 'b' ] ],
+                ]]]]);
+
                 $hml->namespace('svg', 'http://svg.org');
                 $hml->query('//body')
-                        ->add('svg', true)
-                            ->add('shape');
+                        ->add('svg:svg', true)
+                            ->add('svg:shape')
+                            ->add('svg:shape');
 
                 it('should support the CSS selector A', function () use ($hml) {
                         $actual   = $hml->query('p')->array();
-                        $expected = $hml->query('.//p')->array();
+                        $expected = $hml->query('//p')->array();
                         \assert($actual === $expected, __($actual, $expected));
 
-                        $expected = $hml->query('//p')->array();
+                        $actual   = $hml->query('p')->size();
+                        $expected = 3;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
@@ -2802,17 +2809,29 @@ describe('CssTranslator', function () {
                         $actual   = $hml->query('svg|shape')->array();
                         $expected = $hml->query('//svg:shape')->array();
                         \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('svg|shape')->size();
+                        $expected = 2;
+                        \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector :root', function () use ($hml) {
                         $actual   = $hml->query(':root')->array();
                         $expected = $hml->query('/*')->array();
                         \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query(':root')->size();
+                        $expected = 1;
+                        \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector #id', function () use ($hml) {
                         $actual   = $hml->query('#123')->array();
                         $expected = $hml->query('//*[@id="123"]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('#123')->size();
+                        $expected = 1;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
@@ -2821,38 +2840,70 @@ describe('CssTranslator', function () {
                         $expected = $hml->query('//p')->array();
                         \assert($actual === $expected, __($actual, $expected));
 
+                        $actual   = $hml->query('.a')->size();
+                        $expected = 3;
+                        \assert($actual === $expected, __($actual, $expected));
+
                         $actual   = $hml->query('.a.b')->array();
                         $expected = $hml->query('//p[2]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('.a.b')->size();
+                        $expected = 1;
                         \assert($actual === $expected, __($actual, $expected));
 
                         $actual   = $hml->query('h1.b')->array();
                         $expected = $hml->query('//h1')->array();
                         \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('h1.b')->size();
+                        $expected = 1;
+                        \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector [attr]', function () use ($hml) {
                         $actual   = $hml->query('[class]')->array();
-                        $expected = $hml->query('//div//*')->array();
+                        $expected = $hml->query('//div/*')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('[class]')->size();
+                        $expected = 6;
                         \assert($actual === $expected, __($actual, $expected));
 
                         $actual   = $hml->query('[id]')->array();
                         $expected = $hml->query('//*[@id]')->array();
                         \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('[id]')->size();
+                        $expected = 1;
+                        \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector [attr="val"]', function () use ($hml) {
-                        $actual   = $hml->query('[id="123"]')->array();
-                        $expected = $hml->query('//*[@id]')->array();
-                        \assert($actual === $expected, __($actual, $expected));
-
                         $actual   = $hml->query('p[id="123"]')->array();
                         $expected = $hml->query('//p[@id]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('p[id="123"]')->size();
+                        $expected = 1;
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('[class="a"]')->array();
+                        $expected = $hml->query('//*[@class="a"]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('[class="a"]')->size();
+                        $expected = 2;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector A B', function () use ($hml) {
-                        $actual   = $hml->query('body p')->array();
-                        $expected = $hml->query('//body//p')->array();
+                        $actual   = $hml->query('div span')->array();
+                        $expected = $hml->query('//div//span')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('div span')->size();
+                        $expected = 2;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
@@ -2861,8 +2912,8 @@ describe('CssTranslator', function () {
                         $expected = $hml->query('//div/p')->array();
                         \assert($actual === $expected, __($actual, $expected));
 
-                        $actual   = $hml->query('body > p')->array();
-                        $expected = $hml->query('//body/p')->array();
+                        $actual   = $hml->query('div > p')->size();
+                        $expected = 3;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
@@ -2870,23 +2921,39 @@ describe('CssTranslator', function () {
                         $actual   = $hml->query('p, div')->array();
                         $expected = $hml->query('//p|//div')->array();
                         \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('p, div')->size();
+                        $expected = 4;
+                        \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector A + B', function () use ($hml) {
                         $actual   = $hml->query('p + p')->array();
-                        $expected = $hml->query('//p[2]', '//p[3]')->array();
+                        $expected = $hml->query('//p[3]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('p + p')->size();
+                        $expected = 1;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support the CSS selector A ~ B', function () use ($hml) {
-                        $actual   = $hml->query('p ~ h1')->array();
-                        $expected = $hml->query('//h1')->array();
+                        $actual   = $hml->query('h1 ~ p')->array();
+                        $expected = $hml->query('//p[2]|//p[3]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('h1 ~ p')->size();
+                        $expected = 2;
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
                 it('should support mixing CSS selectors :root #123 span, div, :root .a', function () use ($hml) {
                         $actual   = $hml->query(':root #123 span, div, :root .a')->array();
-                        $expected = $hml->query('//span', '//div', '//p')->array();
+                        $expected = $hml->query('//p/span|//div|//*[@class="a"]|//*[@class="a b"]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query(':root #123 span, div, :root .a')->size();
+                        $expected = 5;
                         \assert($actual === $expected, __($actual, $expected));
                 });
         });

--- a/specs/FluidXml.php
+++ b/specs/FluidXml.php
@@ -2815,6 +2815,16 @@ describe('CssTranslator', function () {
                         \assert($actual === $expected, __($actual, $expected));
                 });
 
+                it('should support the CSS selector *|A', function () use ($hml) {
+                        $actual   = $hml->query('*|shape')->array();
+                        $expected = $hml->query('[local-name() = "shape"]')->array();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $actual   = $hml->query('*|shape')->size();
+                        $expected = 3;
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+
                 it('should support the CSS selector :root', function () use ($hml) {
                         $actual   = $hml->query(':root')->array();
                         $expected = $hml->query('/*')->array();


### PR DESCRIPTION
I refactored most of the CssTranslator tests (added the `size()` assertion because I found some of the queries as written were not matching anything, so `->array()` returned empty).

Then I added support for a namespace wildcard with CSS style queries.

(Good job on the library by the way! I've been using it recently, and I found myself needing this feature.)