### PR TITLE
'getText' method

### DIFF
--- a/source/FluidXml/FluidAliasesTrait.php
+++ b/source/FluidXml/FluidAliasesTrait.php
@@ -10,7 +10,7 @@ trait FluidAliasesTrait
         public function prepend($sibling, ...$optionals) { return $this->prependSibling($sibling, ...$optionals); }
         public function append($sibling, ...$optionals)  { return $this->appendSibling($sibling, ...$optionals); }
         public function attr($name, $value = null)       { return $this->setAttribute($name, $value); }
-        public function text($text)                      { return $this->setText($text); }
+        public function text($text = null)               { return $text ? $this->setText($text) : $this->getText(); }
         public function cdata($text)                     { return $this->setCdata($text); }
         public function comment($text)                   { return $this->setComment($text); }
         abstract public function length();
@@ -19,6 +19,7 @@ trait FluidAliasesTrait
         abstract public function prependSibling($sibling, ...$optionals);
         abstract public function appendSibling($sibling, ...$optionals);
         abstract public function setAttribute($name, $value = null);
+        abstract public function getText($glue = PHP_EOL);
         abstract public function setText($text);
         abstract public function setCdata($text);
         abstract public function setComment($text);

--- a/source/FluidXml/FluidContext.php
+++ b/source/FluidXml/FluidContext.php
@@ -286,6 +286,11 @@ class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
                 return $this;
         }
 
+        public function getText($glue = PHP_EOL)
+        {
+                return implode($glue, $this->map(function ($i, $n) { return $n->textContent; }));
+        }
+
         public function setText($text)
         {
                 foreach ($this->nodes as $n) {

--- a/source/FluidXml/FluidInterface.php
+++ b/source/FluidXml/FluidInterface.php
@@ -27,6 +27,7 @@ interface FluidInterface
         public function attr($name, $value = null);
         public function setAttribute($name, $value = null);
         public function text($text);
+        public function getText($glue = PHP_EOL);
         public function setText($text);
         public function addText($text);
         public function cdata($text);

--- a/source/FluidXml/FluidXml.php
+++ b/source/FluidXml/FluidXml.php
@@ -212,6 +212,7 @@ class FluidXml implements FluidInterface
         public function map(callable $fn)                  { return $this->context()->map($fn); }
         public function filter(callable $fn)               { return $this->context()->filter($fn); }
         public function setAttribute($name, $value = null) { $this->context()->setAttribute($name, $value); return $this; }
+        public function getText($glue = PHP_EOL)           { return $this->context()->getText($glue); }
         public function setText($text)                     { $this->context()->setText($text);    return $this; }
         public function addText($text)                     { $this->context()->addText($text);    return $this; }
         public function setCdata($text)                    { $this->context()->setCdata($text);   return $this; }

--- a/specs/FluidXml.php
+++ b/specs/FluidXml.php
@@ -1846,6 +1846,46 @@ EOF;
                 });
         });
 
+        describe('.getText()', function () {
+                it('should get the text content of a node and its children', function () {
+                        $xml = new FluidXml('
+                                <doc>
+                                  <parent>
+                                    <child>child1</child>
+                                    <child/>
+                                    <child>child2</child>
+                                  </parent>
+                                </doc>
+                        ');
+
+                        $expected = 'child1child2';
+                        $actual = $xml->getText();
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+
+                it('should get the text of all nodes inside the context', function () {
+                        $xml = new FluidXml('
+                                <doc>
+                                  <parent>
+                                    <child>child1</child>
+                                    <child/>
+                                    <child>child2</child>
+                                  </parent>
+                                </doc>
+                        ');
+
+                        $expected = 'child1' . PHP_EOL . PHP_EOL . 'child2';
+                        $actual = $xml->query('child')->getText();
+                        \assert($actual === $expected, __($actual, $expected));
+
+                        $expected = 'child1, child2';
+                        $actual = $xml->query('child')->filter(function ($i, $n) {
+                                return (bool) $n->nodeValue;
+                        })->getText(', ');
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+        });
+
         describe('.setText()', function () {
                 it('should be fluid', function () {
                         assert_is_fluid('setText', 'a');
@@ -1874,11 +1914,24 @@ EOF;
         });
 
         describe('.text()', function () {
+                it('should behave like .getText()', function () {
+                        $xml = new FluidXml('<doc>
+                            <child>child11</child>
+                            <child>child22</child>
+                        </doc>');
+
+                        $actual   = $xml->query('child')->text();
+                        $expected = $xml->query('child')->getText();
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+        });
+
+        describe('.text($text)', function () {
                 it('should be fluid', function () {
                         assert_is_fluid('text', 'a');
                 });
 
-                it('should behave like .setText()', function () {
+                it('should behave like .setText($text)', function () {
                         $xml = new FluidXml();
                         $xml->setText('Text1')
                             ->addChild('child', true)


### PR DESCRIPTION
Added `->getText()` that returns the text content of nodes in a context.
Also short version as `->text()` (no parameter).
--> What do you think of `PHP_EOL` as default? Maybe `','` better? Or `''` ?
