### PR TITLE
Allow for xmlStandalone

### DIFF
--- a/source/FluidXml/FluidXml.php
+++ b/source/FluidXml/FluidXml.php
@@ -90,6 +90,9 @@ class FluidXml implements FluidInterface
                 $dom = new \DOMDocument($options['version'], $options['encoding']);
                 $dom->formatOutput       = true;
                 $dom->preserveWhiteSpace = false;
+                if (array_key_exists('standalone', $options)) {
+                    $dom->xmlStandalone = (bool) $options['standalone'];
+                }
 
                 return $dom;
         }


### PR DESCRIPTION
Added a check that $options['standalone'] = bool generates standalone declaration.

`new FluidXML('books', ['standalone' => true]);`
produces
`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`