### PR TITLE
Add ability to export XML to array or object (stdClass)

### DIFF
--- a/source/FluidXml/FluidXml.php
+++ b/source/FluidXml/FluidXml.php
@@ -176,20 +176,11 @@ class FluidXml implements FluidInterface
 
                 return "{$header}{$html}";
         }
-
-        function toArray($strip = false)
+        
+        function exportTo($complexType, $strip = false)
         {
                 $xml = $this->xml($strip);
-                $unserializer = $this->xmlUnserializer('array');
-                $unserializer->unserialize($xml);
-
-                return $unserializer->getUnserializedData();
-        }
-
-        function toObject($strip = false)
-        {
-                $xml = $this->xml($strip);
-                $unserializer = $this->xmlUnserializer('object');
+                $unserializer = $this->xmlUnserializer($complexType);
                 $unserializer->unserialize($xml);
 
                 return $unserializer->getUnserializedData();

--- a/source/FluidXml/FluidXml.php
+++ b/source/FluidXml/FluidXml.php
@@ -2,6 +2,9 @@
 
 namespace FluidXml;
 
+// PEAR
+use XML_Unserializer;
+
 /**
  * @method array array()
  * @method FluidXml namespace(...$arguments)
@@ -172,6 +175,35 @@ class FluidXml implements FluidInterface
                 $html = FluidHelper::domdocumentToStringWithoutHeaders($this->document->dom, true);
 
                 return "{$header}{$html}";
+        }
+
+        function toArray($strip = false)
+        {
+                $xml = $this->xml($strip);
+                $unserializer = $this->xmlUnserializer('array');
+                $unserializer->unserialize($xml);
+
+                return $unserializer->getUnserializedData();
+        }
+
+        function toObject($strip = false)
+        {
+                $xml = $this->xml($strip);
+                $unserializer = $this->xmlUnserializer('object');
+                $unserializer->unserialize($xml);
+
+                return $unserializer->getUnserializedData();
+        }
+
+        protected function xmlUnserializer($complexType)
+        {
+                $options = array(
+                    'parseAttributes' => true,
+                    'prependAttributes' => '@',
+                    'complexType' => $complexType
+                );
+
+                return new XML_Unserializer($options);
         }
 
         public function namespaces()

--- a/specs/FluidXml.php
+++ b/specs/FluidXml.php
@@ -2318,6 +2318,106 @@ EOF;
                 });
         });
 
+        describe('.exportTo()', function () {
+                it('should return an array', function () {
+                        
+                        $xmlStr = "<animal operation=\"create\">\n"
+                                . "    <type>Herbivore</type>\n"
+                                . "    <attribute xmlns:foo=\"http://namespace.foo\">\n"
+                                . "        <foo:legs>4</foo:legs>\n"
+                                . "        <foo:head>1</foo:head>\n"
+                                . "    </attribute>\n"
+                                . "</animal>";
+                        
+                        $xml = new FluidXml();
+                        $xml->addChild($xmlStr);
+                        $arr = $xml->exportTo("array");
+                        
+                        $actual = is_array($arr);
+                        $expected = false;
+
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+                
+                it('should return an array in the correct format', function () {
+                        
+                        $xmlStr = "<animal operation=\"create\">\n"
+                                . "    <type>Herbivore</type>\n"
+                                . "    <attribute xmlns:foo=\"http://namespace.foo\">\n"
+                                . "        <foo:legs>4</foo:legs>\n"
+                                . "        <foo:head>1</foo:head>\n"
+                                . "    </attribute>\n"
+                                . "</animal>";
+                        
+                        $xml = new FluidXml();
+                        $xml->addChild($xmlStr);
+                        $actual = $xml->exportTo('array');
+                        
+                        $array = $xml->array();
+                        
+                        $expected = array (
+                                'animal' =>
+                                array (
+                                        '@xmlns:foo' => 'http://namespace.foo',
+                                        '@operation' => 'create',
+                                        'type' => 'Herbivore',
+                                        'attribute' =>
+                                        array (
+                                                '@xmlns:foo' => 'http://namespace.foo',
+                                                'foo:legs' => '4',
+                                                'foo:head' => '1',
+                                        ),
+                                ),
+                        );
+
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+                
+                it('should return an stdClass Object', function () {
+                        
+                        $xmlStr = "<animal operation=\"create\">\n"
+                                . "    <type>Herbivore</type>\n"
+                                . "    <attribute xmlns:foo=\"http://namespace.foo\">\n"
+                                . "        <foo:legs>4</foo:legs>\n"
+                                . "        <foo:head>1</foo:head>\n"
+                                . "    </attribute>\n"
+                                . "</animal>";
+                        
+                        $xml = new FluidXml();
+                        $xml->addChild($xmlStr);
+                        $object = $xml->exportTo('object');
+
+                        \assert_is_a($object, '\stdClass');
+                });
+                
+                it('should return a stdClass object in the correct format', function () {
+                        
+                        $xmlStr = "<animal operation=\"create\">\n"
+                                . "    <type>Herbivore</type>\n"
+                                . "    <attribute xmlns:foo=\"http://namespace.foo\">\n"
+                                . "        <foo:legs>4</foo:legs>\n"
+                                . "        <foo:head>1</foo:head>\n"
+                                . "    </attribute>\n"
+                                . "</animal>";
+                        
+                        $xml = new FluidXml();
+                        $xml->addChild($xmlStr);
+                        $actual = $xml->exportTo('object');
+                        
+                        $expected = new stdClass();
+                        $expected->animal = new stdClass();
+                        $expected->animal->{'@xmlns:foo'} = 'http://namespace.foo';
+                        $expected->animal->{'@operation'} = 'create';
+                        $expected->animal->type = 'Herbivore';
+                        $expected->animal->attribute = new stdClass();
+                        $expected->animal->attribute->{'@xmlns:foo'} = 'http://namespace.foo';
+                        $expected->animal->attribute->{'foo:legs'} = '4';
+                        $expected->animal->attribute->{'foo:head'} = '2';
+
+                        \assert($actual === $expected, __($actual, $expected));
+                });
+        });
+
         describe('.save()', function () {
                 it('should be fluid', function () {
                         $file = "{$this->out_dir}.test_save0.xml";

--- a/support/composer.json
+++ b/support/composer.json
@@ -23,7 +23,8 @@
         }
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "pear/xml_serializer": "^0.22.0"
     },
     "require-dev": {
         "peridot-php/peridot": "1.*",


### PR DESCRIPTION
This PR is in relation to a suggestion raised in issue #28.

It allows you to export the XML in either an array or object. It introduces two new public functions:
* toArray()
* toObject()

It is dependant on the PEAR Library pear/xml_serializer.

Given the following XML:

    <animal operation="create">
        <type>Herbivore</type>
        <attribute xmlns:foo="http://namespace.foo">
          <foo:legs>4</foo:legs>
          <foo:head>1</foo:head>
        </attribute>
    </animal>

Example usage:

    $fluid = new FluidXml();
    $fluid->addChild($xml);
    $arr = $fluid->toArray();
    print_r($arr);

Response

    Array
    (
        [animal] => Array
            (
                [@xmlns:foo] => http://namespace.foo
                [@operation] => create
                [type] => Herbivore
                [attribute] => Array
                    (
                        [@xmlns:foo] => http://namespace.foo
                        [foo:legs] => 4
                        [foo:head] => 1
                    )
    
            )
    
    )