### PR TITLE
Compatibility for some parts of the code with PHP 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ documents/api/
 private/
 sandbox/
 composer.lock
+.idea

--- a/source/FluidXml/FluidContext.php
+++ b/source/FluidXml/FluidContext.php
@@ -8,10 +8,10 @@ namespace FluidXml;
 class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
 {
         use FluidAliasesTrait,
-            FluidSaveTrait,
-            NewableTrait,
-            ReservedCallTrait,          // For compatibility with PHP 5.6.
-            ReservedCallStaticTrait;    // For compatibility with PHP 5.6.
+                FluidSaveTrait,
+                NewableTrait,
+                ReservedCallTrait,          // For compatibility with PHP 5.6.
+                ReservedCallStaticTrait;    // For compatibility with PHP 5.6.
 
         private $document;
         private $handler;
@@ -39,7 +39,7 @@ class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
         }
 
         // \ArrayAccess interface.
-        public function offsetSet($offset, $value)
+        public function offsetSet($offset, $value): void
         {
                 // if (\is_null($offset)) {
                 //         $this->nodes[] = $value;
@@ -50,20 +50,20 @@ class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
         }
 
         // \ArrayAccess interface.
-        public function offsetExists($offset)
+        public function offsetExists($offset): bool
         {
                 return isset($this->nodes[$offset]);
         }
 
         // \ArrayAccess interface.
-        public function offsetUnset($offset)
+        public function offsetUnset($offset): void
         {
                 // unset($this->nodes[$offset]);
                 \array_splice($this->nodes, $offset, 1);
         }
 
         // \ArrayAccess interface.
-        public function offsetGet($offset)
+        public function offsetGet($offset): mixed
         {
                 if (isset($this->nodes[$offset])) {
                         return $this->nodes[$offset];
@@ -73,31 +73,31 @@ class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
         }
 
         // \Iterator interface.
-        public function rewind()
+        public function rewind(): void
         {
                 $this->seek = 0;
         }
 
         // \Iterator interface.
-        public function current()
+        public function current(): mixed
         {
                 return $this->nodes[$this->seek];
         }
 
         // \Iterator interface.
-        public function key()
+        public function key(): mixed
         {
                 return $this->seek;
         }
 
         // \Iterator interface.
-        public function next()
+        public function next(): void
         {
                 ++$this->seek;
         }
 
         // \Iterator interface.
-        public function valid()
+        public function valid(): bool
         {
                 return isset($this->nodes[$this->seek]);
         }
@@ -408,9 +408,9 @@ class FluidContext implements FluidInterface, \ArrayAccess, \Iterator
         protected function resolveQuery($query)
         {
                 if ( $query === '.'
-                     || $query[0] === '/'
-                     || ( $query[0] === '.' && $query[1] === '/' )
-                     || ( $query[0] === '.' && $query[1] === '.' ) ) {
+                        || $query[0] === '/'
+                        || ( $query[0] === '.' && $query[1] === '/' )
+                        || ( $query[0] === '.' && $query[1] === '.' ) ) {
                         return $query;
                 }
 

--- a/source/FluidXml/FluidHelper.php
+++ b/source/FluidXml/FluidHelper.php
@@ -6,6 +6,9 @@ class FluidHelper
 {
         public static function isAnXmlString($string)
         {
+                if (is_null($string)) {
+                        $string = '';
+                }
                 // Removes any empty new line at the beginning,
                 // otherwise the first character check may fail.
                 $string = \ltrim($string);

--- a/source/FluidXml/FluidInsertionHandler.php
+++ b/source/FluidXml/FluidInsertionHandler.php
@@ -198,6 +198,9 @@ class FluidInsertionHandler
                         }
                 }
 
+                if (is_null($uri)) {
+                        $uri = '';
+                }
                 // Algorithm 1:
                 $el = new \DOMElement($name, $value, $uri);
 

--- a/support/composer.json
+++ b/support/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.4"
     },
     "require-dev": {
         "peridot-php/peridot": "1.*",


### PR DESCRIPTION
I found some areas where PHP deprecation notices were being thrown due to the new stricter "Passing null to non-nullable internal function parameters is deprecated." change (https://www.php.net/releases/8.1/en.php) while using the package. 
There were also issues with `FluidContext` requiring the `\Iterator` interface's enforced return types be declared in the overridden methods inside the class so I added the return types.
This does not completely port the codebase to where it ought to get to, but I didn't want to also have a fork that remained separate for things that should be included in maintaining this package.

I also bumped minimum version requirement to PHP 7.4 to ensure the compatibility with return types is available.