### PR TITLE
Support PHP 8.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ documents/api/
 private/
 sandbox/
 composer.lock
+.idea

--- a/documents/Changelog.txt
+++ b/documents/Changelog.txt
@@ -1,6 +1,6 @@
 [+]: new   [~]: changed   [-]: removed   [#]: fixed   [@]: internal
 
-1.3.0: (2023-11-06)
+2.0.0: (2023-11-06)
 bump support and syntax changes to PHP 8.1+
 
     [~] Changed:
@@ -207,7 +207,7 @@ improves the removal of nodes.
   * ->remove() can remove the results of a query and accepts multiple XPath strings.
 
 
-1.3:
+2.0:
 helps customizing the root element of a document.
 
   [~] Changed:

--- a/documents/Changelog.txt
+++ b/documents/Changelog.txt
@@ -1,5 +1,10 @@
 [+]: new   [~]: changed   [-]: removed   [#]: fixed   [@]: internal
 
+1.3.0: (2023-11-06)
+bump support and syntax changes to PHP 8.1+
+
+    [~] Changed:
+    * PHP 8.1+ is the minimum version.
 
 1.20.3: (2016-07-12)
 fixes wrong handling of null/empty node value.

--- a/documents/ReadMe.md
+++ b/documents/ReadMe.md
@@ -241,7 +241,7 @@ But you'll have the best answer trying it yourself.
 
 
 ## Requirements
-* PHP 5.6
+* PHP 8.1+
 
 
 ## Installation

--- a/documents/ReadMe.md
+++ b/documents/ReadMe.md
@@ -48,7 +48,7 @@
 
 ## Changelog
 
-**1.3.0** (2023-11-06):
+**2.0.0** (2023-11-06):
 _Support PHP 8.1+_
 
 **...**
@@ -315,7 +315,6 @@ your immense gratitude **[♥][thankyou]**, _buy me a coffe_.
 
 
 ## Roadmap
-* [x] PHP 5.6 backport
 * [ ] Extending the documentation
 * [ ] Expanding the APIs
 

--- a/documents/ReadMe.md
+++ b/documents/ReadMe.md
@@ -48,8 +48,8 @@
 
 ## Changelog
 
-**1.20.3** (2016-07-12):
-_fixes wrong handling of null/empty node value._
+**1.3.0** (2023-11-06):
+_Support PHP 8.1+_
 
 **...**
 

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/documents',
+        __DIR__ . '/source',
+        __DIR__ . '/specs',
+        __DIR__ . '/support',
+    ]);
+
+    $rectorConfig->rules([
+            InlineConstructorDefaultToPropertyRector::class,
+            NullToStrictStringFuncCallArgRector::class,
+    ]);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_82
+    ]);
+};

--- a/source/FluidXml/CssTranslator.php
+++ b/source/FluidXml/CssTranslator.php
@@ -4,8 +4,8 @@ namespace FluidXml;
 
 class CssTranslator
 {
-        const TOKEN = '/{([[:alpha:]]+)(\d+)}/i';
-        const MAP = [
+        final public const TOKEN = '/{([[:alpha:]]+)(\d+)}/i';
+        final public const MAP = [
                 // Empty part of #id and .class
                 [ '(?<=^|\s)      # The begining or an empty space.
                    (?=[.#\[])     # . | # | [',
@@ -126,7 +126,7 @@ class CssTranslator
 
                 foreach (self::MAP as $o) {
                         // The regexes have a common wrapper.
-                        list($search, $replace, $id, $repeat) = $o;
+                        [$search, $replace, $id, $repeat] = $o;
                         $search = "/{$search}/xi";
 
                         do {
@@ -137,7 +137,7 @@ class CssTranslator
 
                 self::translateStack($stack, $xpath);
 
-                $xpath = \trim($xpath);
+                $xpath = \trim((string) $xpath);
                 $xpath = ".//$xpath";
                 $xpath = \str_replace('|', '|.//',   $xpath);
                 $xpath = \str_replace('.///', '/', $xpath);
@@ -148,7 +148,7 @@ class CssTranslator
         protected static function tokenize($search, $replace, $id, &$xpath, &$stack, &$index)
         {
                 // The search can return 0, 1 or more fund patterns.
-                $matches_count = \preg_match_all($search, $xpath, $matches, \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE);
+                $matches_count = \preg_match_all($search, (string) $xpath, $matches, \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE);
 
                 // \PREG_OFFSET_CAPTURE calculates offsets starting from the begining of the string $xpath.
                 // Rewriting $xpath from left (first matches) creates a mismatch between the calculated offsets
@@ -163,9 +163,9 @@ class CssTranslator
                         // $match[>0] are the captured groups.
                         // $match[n][0] is the actual string.
                         // $match[n][1] is the position of the string.
-                        list($pattern, $pattern_pos) = $match[0];
+                        [$pattern, $pattern_pos] = $match[0];
 
-                        $xpath = \substr_replace($xpath, "{{$id}{$index}}", $pattern_pos, \strlen($pattern));
+                        $xpath = \substr_replace((string) $xpath, "{{$id}{$index}}", $pattern_pos, \strlen($pattern));
 
                         $groups_values = [];
                         for ($ii = 1; $ii <= $groups_count; ++$ii) {
@@ -181,20 +181,20 @@ class CssTranslator
         protected static function translateStack(&$stack, &$xpath)
         {
                 do {
-                        $matches_count = \preg_match_all(self::TOKEN, $xpath, $matches, \PREG_SET_ORDER);
+                        $matches_count = \preg_match_all(self::TOKEN, (string) $xpath, $matches, \PREG_SET_ORDER);
 
                         for ($i = 0; $i < $matches_count; ++$i) {
-                                list(, $type, $id) = $matches[$i];
+                                [, $type, $id] = $matches[$i];
 
                                 $id = \intval($id);
 
-                                list($replace, $groups) = $stack[$id];
+                                [$replace, $groups] = $stack[$id];
 
                                 foreach ($groups as $k => $v) {
-                                        $replace = \str_replace("\\$k", $v, $replace);
+                                        $replace = \str_replace("\\$k", $v, (string) $replace);
                                 }
 
-                                $xpath = \str_replace("{{$type}{$id}}", $replace, $xpath);
+                                $xpath = \str_replace("{{$type}{$id}}", $replace, (string) $xpath);
                         }
                 } while ($matches_count > 0);
         }

--- a/source/FluidXml/FluidHelper.php
+++ b/source/FluidXml/FluidHelper.php
@@ -4,16 +4,16 @@ namespace FluidXml;
 
 class FluidHelper
 {
-        public static function isAnXmlString($string)
+        public static function isAnXmlString($string): bool
         {
                 // Removes any empty new line at the beginning,
                 // otherwise the first character check may fail.
-                $string = \ltrim($string);
+                $string = \ltrim((string) $string);
 
                 return $string && $string[0] === '<';
         }
 
-        public static function exportNode(\DOMDocument $dom, \DOMNode $node, $html = false)
+        public static function exportNode(\DOMDocument $dom, \DOMNode $node, $html = false): array|bool|string|null
         {
                 // $delegate = $html ? 'saveHTML' : 'saveXML';
                 // return $dom->$delegate($node);
@@ -25,12 +25,12 @@ class FluidHelper
                 return $dom->saveXML($node);
         }
 
-        public static function domdocumentToStringWithoutHeaders(\DOMDocument $dom, $html = false)
+        public static function domdocumentToStringWithoutHeaders(\DOMDocument $dom, $html = false): bool|array|string|null
         {
                 return static::exportNode($dom, $dom->documentElement, $html);
         }
 
-        public static function domnodelistToString(\DOMNodeList $nodelist, $html = false)
+        public static function domnodelistToString(\DOMNodeList $nodelist, $html = false): string
         {
                 $nodes = [];
 
@@ -47,7 +47,7 @@ class FluidHelper
                 return static::domnodesToString($nodes, $html);
         }
 
-        public static function domnodesToString(array $nodes, $html = false)
+        public static function domnodesToString(array $nodes, $html = false): string
         {
                 $dom = $nodes[0]->ownerDocument;
                 $xml = '';
@@ -59,14 +59,14 @@ class FluidHelper
                 return \rtrim($xml);
         }
 
-        public static function simplexmlToStringWithoutHeaders(\SimpleXMLElement $element, $html = false)
+        public static function simplexmlToStringWithoutHeaders(\SimpleXMLElement $element, $html = false): bool|array|string|null
         {
                 $dom = \dom_import_simplexml($element);
 
                 return static::exportNode($dom->ownerDocument, $dom, $html);
         }
 
-        public static function domdocumentToHtml($dom, $clone = true)
+        public static function domdocumentToHtml($dom, $clone = true): array|string|null
         {
                 if ($clone) {
                         $dom = $dom->cloneNode(true);
@@ -105,12 +105,12 @@ class FluidHelper
                 $html = static::domdocumentToStringWithoutHeaders($dom);
 
                 // Let's remove the placeholder.
-                $html = \preg_replace('/\s*<\?X-NOT-VOID\?>\s*/', '', $html);
+                $html = \preg_replace('/\s*<\?X-NOT-VOID\?>\s*/', '', (string) $html);
 
                 return $html;
         }
 
-        public static function domnodeToHtml(\DOMNode $node)
+        public static function domnodeToHtml(\DOMNode $node): array|string|null
         {
                 $dom = new \DOMDocument();
                 $dom->formatOutput       = true;

--- a/source/FluidXml/FluidNamespace.php
+++ b/source/FluidXml/FluidNamespace.php
@@ -4,14 +4,14 @@ namespace FluidXml;
 
 class FluidNamespace
 {
-        const ID   = 'id'  ;
-        const URI  = 'uri' ;
-        const MODE = 'mode';
+        final public const ID   = 'id'  ;
+        final public const URI  = 'uri' ;
+        final public const MODE = 'mode';
 
-        const MODE_IMPLICIT = 0;
-        const MODE_EXPLICIT = 1;
+        final public const MODE_IMPLICIT = 0;
+        final public const MODE_EXPLICIT = 1;
 
-        private $config = [ self::ID   => '',
+        private array $config = [ self::ID   => '',
                             self::URI  => '',
                             self::MODE => self::MODE_EXPLICIT ];
 
@@ -49,7 +49,7 @@ class FluidNamespace
                 // Relative queries are an example '../target".
                 $new_xpath = '';
 
-                $nodes = \explode('/', $xpath);
+                $nodes = \explode('/', (string) $xpath);
 
                 foreach ($nodes as $node) {
                         if (! empty($node)) {

--- a/source/FluidXml/FluidRepeater.php
+++ b/source/FluidXml/FluidRepeater.php
@@ -4,17 +4,8 @@ namespace FluidXml;
 
 class FluidRepeater
 {
-        private $document;
-        private $handler;
-        private $context;
-        private $times;
-
-        public function __construct($document, $handler, $context, $times)
+        public function __construct(private $document, private $handler, private $context, private $times)
         {
-                $this->document = $document;
-                $this->handler  = $handler;
-                $this->context  = $context;
-                $this->times    = $times;
         }
 
         public function __call($method, $arguments)

--- a/source/FluidXml/FluidSaveTrait.php
+++ b/source/FluidXml/FluidSaveTrait.php
@@ -4,7 +4,10 @@ namespace FluidXml;
 
 trait FluidSaveTrait
 {
-        public function save($file, $strip = false)
+        /**
+         * @throws \Exception
+         */
+        public function save($file, $strip = false): static
         {
                 $status = \file_put_contents($file, $this->xml($strip));
 

--- a/source/FluidXml/FluidXml.php
+++ b/source/FluidXml/FluidXml.php
@@ -14,16 +14,16 @@ class FluidXml implements FluidInterface
             ReservedCallTrait,          // For compatibility with PHP 5.6.
             ReservedCallStaticTrait;    // For compatibility with PHP 5.6.
 
-        const ROOT_NODE = 'doc';
+        final public const ROOT_NODE = 'doc';
 
-        private $defaults = [ 'root'       => self::ROOT_NODE,
+        private array $defaults = [ 'root'       => self::ROOT_NODE,
                               'version'    => '1.0',
                               'encoding'   => 'UTF-8',
                               'stylesheet' => null ];
 
-        private $document;
-        private $handler;
-        private $context;
+        private readonly \FluidXml\FluidDocument $document;
+        private readonly \FluidXml\FluidInsertionHandler $handler;
+        private ?\FluidXml\FluidContext $context = null;
         private $contextEl;
 
         public static function load($document)
@@ -66,7 +66,7 @@ class FluidXml implements FluidInterface
                      ->initRoot($options);
         }
 
-        protected function mergeOptions(&$arguments)
+        protected function mergeOptions(&$arguments): array
         {
                 $options = $this->defaults;
 
@@ -85,7 +85,7 @@ class FluidXml implements FluidInterface
                 return $options;
         }
 
-        private function newDom(&$options)
+        private function newDom(&$options): \DOMDocument
         {
                 $dom = new \DOMDocument($options['version'], $options['encoding']);
                 $dom->formatOutput       = true;
@@ -94,7 +94,7 @@ class FluidXml implements FluidInterface
                 return $dom;
         }
 
-        private function initStylesheet(&$options)
+        private function initStylesheet(&$options): static
         {
                 if (! empty($options['stylesheet'])) {
                         $attrs = 'type="text/xsl" '
@@ -114,7 +114,7 @@ class FluidXml implements FluidInterface
                 return $this;
         }
 
-        private function initRoot(&$options)
+        private function initRoot(&$options): static
         {
                 if (! empty($options['root'])) {
                         $this->appendSibling($options['root']);
@@ -123,7 +123,7 @@ class FluidXml implements FluidInterface
                 return $this;
         }
 
-        public function length()
+        public function length(): int
         {
                 return \count($this->array());
         }
@@ -136,7 +136,7 @@ class FluidXml implements FluidInterface
         // This method should be called 'array',
         // but for compatibility with PHP 5.6
         // it is shadowed by the __call() method.
-        public function array_()
+        public function array_(): array
         {
                 $el = $this->document->dom->documentElement;
 
@@ -147,9 +147,9 @@ class FluidXml implements FluidInterface
                 return [ $el ];
         }
 
-        public function __toString()
+        public function __toString(): string
         {
-                return $this->xml();
+                return (string) $this->xml();
         }
 
         public function xml($strip = false)
@@ -161,7 +161,7 @@ class FluidXml implements FluidInterface
                 return $this->document->dom->saveXML();
         }
 
-        public function html($strip = false)
+        public function html($strip = false): string
         {
                 $header = "<!DOCTYPE html>\n";
 
@@ -182,7 +182,7 @@ class FluidXml implements FluidInterface
         // This method should be called 'namespace',
         // but for compatibility with PHP 5.6
         // it is shadowed by the __call() method.
-        protected function namespace_(...$arguments)
+        protected function namespace_(...$arguments): static
         {
                 $namespaces = [];
 
@@ -241,7 +241,10 @@ class FluidXml implements FluidInterface
                 });
         }
 
-        protected function context()
+        /**
+         * @throws \Exception
+         */
+        protected function context(): ?FluidContext
         {
                 $el = $this->document->dom->documentElement;
 
@@ -261,6 +264,9 @@ class FluidXml implements FluidInterface
                 return $this->context;
         }
 
+        /**
+         * @throws \Exception
+         */
         protected function chooseContext(\Closure $fn)
         {
                 // If the user has requested ['root' => null] at construction time

--- a/source/FluidXml/NewableTrait.php
+++ b/source/FluidXml/NewableTrait.php
@@ -7,7 +7,7 @@ trait NewableTrait
         // This method should be called 'new',
         // but for compatibility with PHP 5.6
         // it is shadowed by the __callStatic() method.
-        public static function new_(...$arguments)
+        public static function new_(...$arguments): static
         {
                 return new static(...$arguments);
         }

--- a/source/FluidXml/ReservedCallStaticTrait.php
+++ b/source/FluidXml/ReservedCallStaticTrait.php
@@ -4,6 +4,9 @@ namespace FluidXml;
 
 trait ReservedCallStaticTrait
 {
+        /**
+         * @throws \Exception
+         */
         public static function __callStatic($method, $arguments)
         {
                 $m = "{$method}_";

--- a/source/FluidXml/ReservedCallTrait.php
+++ b/source/FluidXml/ReservedCallTrait.php
@@ -4,6 +4,9 @@ namespace FluidXml;
 
 trait ReservedCallTrait
 {
+        /**
+         * @throws \Exception
+         */
         public function __call($method, $arguments)
         {
                 $m = "{$method}_";

--- a/source/FluidXml/fluid.php
+++ b/source/FluidXml/fluid.php
@@ -2,7 +2,7 @@
 
 namespace FluidXml;
 
-define('FLUIDXML_VERSION', '1.3.0');
+define('FLUIDXML_VERSION', '2.0.0');
 
 function fluidxml(...$arguments): FluidXml
 {

--- a/source/FluidXml/fluid.php
+++ b/source/FluidXml/fluid.php
@@ -2,19 +2,22 @@
 
 namespace FluidXml;
 
-define('FLUIDXML_VERSION', '1.20.2');
+define('FLUIDXML_VERSION', '1.3.0');
 
-function fluidxml(...$arguments)
+function fluidxml(...$arguments): FluidXml
 {
         return new \FluidXml\FluidXml(...$arguments);
 }
 
+/**
+ * @throws \Exception
+ */
 function fluidify(...$arguments)
 {
         return \FluidXml\FluidXml::load(...$arguments);
 }
 
-function fluidns(...$arguments)
+function fluidns(...$arguments): FluidNamespace
 {
         return new \FluidXml\FluidNamespace(...$arguments);
 }

--- a/support/Codevelox.php
+++ b/support/Codevelox.php
@@ -6,13 +6,11 @@ ini_set('display_startup_errors', true);
 
 class Codevelox
 {
-        private $cycles;
-        private $tasks = [];
+        private array $tasks = [];
         private $data;
 
-        public function __construct($cycles = 100000)
+        public function __construct(private $cycles = 100000)
         {
-                $this->cycles = $cycles;
         }
 
         public function data($data)
@@ -26,7 +24,7 @@ class Codevelox
         {
                 $microtime = \microtime();
 
-                list($usec, $sec) = \explode(' ', $microtime);
+                [$usec, $sec] = \explode(' ', $microtime);
 
                 return $sec . \substr($usec, 1);
         }

--- a/support/circle.yml
+++ b/support/circle.yml
@@ -1,6 +1,6 @@
 machine:
     php:
-        version: 5.6.14
+        version: 8.1.24
 dependencies:
     pre:
         - git config --global github.accesstoken 21fd5f444e024f66f292461ca7ea7243f63a200d

--- a/support/composer.json
+++ b/support/composer.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.3.0",
     "name": "servo/fluidxml",
     "description": "Concise and fluent XML manipulation library",
     "type": "library",
@@ -23,11 +24,14 @@
         }
     },
     "require": {
-        "php": ">=5.6"
+        "php": "^8.1",
+        "ext-dom": "*",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "peridot-php/peridot": "1.*",
         "peridot-php/peridot-code-coverage-reporters": "1.*",
-        "apigen/apigen": "4.*"
+        "apigen/apigen": "4.*",
+        "rector/rector": "^0.18.6"
     }
 }

--- a/support/composer.json
+++ b/support/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.0",
+    "version": "2.0.0",
     "name": "servo/fluidxml",
     "description": "Concise and fluent XML manipulation library",
     "type": "library",

--- a/support/coveralls.php
+++ b/support/coveralls.php
@@ -49,13 +49,13 @@ foreach ($data as $file => $c) {
                 $coverage[$i] = $val;
         }
 
-        $file = [ 'name'          => \substr($file, \strlen($root_dir) + 1),
+        $file = [ 'name'          => \substr((string) $file, \strlen($root_dir) + 1),
                   'source_digest' => \md5_file($file),
                   'coverage'      => $coverage ];
 
         $payload['source_files'][] = $file;
 }
 
-$data = \json_encode($payload);
+$data = \json_encode($payload, JSON_THROW_ON_ERROR);
 
 echo $data;

--- a/support/scrutinizer.yml
+++ b/support/scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.0.0
+            version: 8.1.24
     tests:
         override:
             -

--- a/support/speedtest.php
+++ b/support/speedtest.php
@@ -1,6 +1,6 @@
 <?php
 
-$v = isset($argv[1]) ? $argv[1] : __DIR__ . '/../source';
+$v = $argv[1] ?? __DIR__ . '/../source';
 
 require_once 'Codevelox.php';
 require_once "$v/FluidXml.php";
@@ -9,7 +9,7 @@ $machine = new Codevelox(1000);
 
 $fluidxml = 'fluidxml';
 if (! function_exists($fluidxml)) {
-        $fluidxml = '\FluidXml\fluidxml';
+        $fluidxml = '\\' . \FluidXml\fluidxml::class;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/support/tools/testv
+++ b/support/tools/testv
@@ -8,17 +8,17 @@ tester="./support/tools/test"
 
 if ! chkcmd 'brew'; then
         echo ' "brew" command not found.'
-        echo ' Skipping version based testing for PHP {5.6, 7}.'
+        echo ' Skipping version based testing for PHP {8.1, 8.2}.'
 
         "$tester"
 else
-        brew unlink php56 php70 > /dev/null     \
-        && brew link php56      > /dev/null     \
-        && printf "\nTesting against PHP 5.6\n" \
+        brew unlink php@8.1 > /dev/null     \
+        && brew link php@8.1      > /dev/null     \
+        && printf "\nTesting against PHP 8.1\n" \
         && "$tester"                            \
         && clear                                \
-        && brew unlink php56    > /dev/null     \
-        && brew link php70      > /dev/null     \
-        && printf "\nTesting against PHP 7.0\n" \
+        && brew unlink php@8.1    > /dev/null     \
+        && brew link php@8.2      > /dev/null     \
+        && printf "\nTesting against PHP 8.2\n" \
         && "$tester"
 fi

--- a/support/travis.yml
+++ b/support/travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-    - 5.6
-    - 7.0
+    - 8.1
+    - 8.2
 cache:
     directories:
         - sandbox/composer/


### PR DESCRIPTION
- Drop support for unsupported PHP versions. 
- Fix deprecations in DOMElement. 
- Add return types where known. 
- Use Rector for the majority of PHP updates. 
- Bump version to 1.3.0.

Relatively blind update, to bring up to date.